### PR TITLE
Make send an alias for respond

### DIFF
--- a/discord/commands/context.py
+++ b/discord/commands/context.py
@@ -121,6 +121,8 @@ class ApplicationContext(discord.abc.Messageable):
             if self.response.is_done()
             else self.interaction.response.send_message
         )
+    
+    send = respond
 
     @property
     def defer(self):


### PR DESCRIPTION
## Summary
Make `send` an alias for `respond`. 
<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)
